### PR TITLE
Improve IBR error handling

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -178,6 +178,15 @@ delete it.
     # be able to clean up debris in case something goes wrong.
     [ prefix: <string> ]
 
+    # If an error occurs during registration and this is set to true, a
+    # constant metric with `type` and `condition` labels matching the
+    # respective properties of the XMPP error which was returned will be
+    # exported.
+    #
+    # Note that when using this with untrusted servers, they may be able to
+    # cause a high cardinality in these labels, so enable with care.
+    [ export_error_info: <boolean> ]
+
 ```
 
 ### <tls_config>

--- a/example.yml
+++ b/example.yml
@@ -49,3 +49,4 @@ modules:
    ibr:
      prefix: "blackbox-probe-"
      directtls: false
+     export_error_info: true

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -94,9 +94,10 @@ func (r PingResult) Matches(other PingResult) bool {
 }
 
 type IBRProbe struct {
-	Prefix    string           `yaml:"prefix,omitempty"`
-	TLSConfig config.TLSConfig `yaml:"tls_config,omitempty"`
-	DirectTLS bool             `yaml:"directtls,omitempty"`
+	Prefix          string           `yaml:"prefix,omitempty"`
+	TLSConfig       config.TLSConfig `yaml:"tls_config,omitempty"`
+	DirectTLS       bool             `yaml:"directtls,omitempty"`
+	ExportErrorInfo bool             `yaml:"export_error_info,omitempty"`
 }
 
 type Module struct {

--- a/internal/prober/features.go
+++ b/internal/prober/features.go
@@ -215,6 +215,12 @@ func Register(prefix string, server string, account *jid.JID, password *string) 
 				return xmpp.SessionState(0), nil, fmt.Errorf("failed to parse response: %s", err.Error())
 			}
 
+			if response.Type == stanza.ErrorIQ {
+				tmp := &stanza.Error{}
+				*tmp = response.Error
+				return xmpp.SessionState(0), nil, tmp
+			}
+
 			return xmpp.Ready, nil, nil
 		},
 	}

--- a/internal/prober/features.go
+++ b/internal/prober/features.go
@@ -184,10 +184,15 @@ func Register(prefix string, server string, account *jid.JID, password *string) 
 			if err != nil {
 				return xmpp.SessionState(0), nil, err
 			}
+			iqId, err := randomPassword()
+			if err != nil {
+				return xmpp.SessionState(0), nil, err
+			}
 
 			err = session.Send(
 				ctx,
 				stanza.IQ{
+					ID: iqId,
 					Type: stanza.SetIQ,
 				}.Wrap((&RegisterQuery{
 					Username: username,

--- a/internal/prober/ibr.go
+++ b/internal/prober/ibr.go
@@ -175,7 +175,6 @@ func ProbeIBR(ctx context.Context, target string, config config.Module, registry
 		ct.starttlsDone = ct.connectDone
 	}
 	c.durationGaugeVec.WithLabelValues("starttls").Set(ct.starttlsDone.Sub(ct.connectDone).Seconds())
-	c.durationGaugeVec.WithLabelValues("register").Set(ct.authDone.Sub(ct.starttlsDone).Seconds())
 
 	if err != nil {
 		log.Printf("registration failed: %s", err.Error())
@@ -191,6 +190,8 @@ func ProbeIBR(ctx context.Context, target string, config config.Module, registry
 
 		return false
 	}
+
+	c.durationGaugeVec.WithLabelValues("register").Set(ct.authDone.Sub(ct.starttlsDone).Seconds())
 
 	ct, conn, session, err := login(
 		c.ctx,


### PR DESCRIPTION
* Correctly identify IQ error during registration and abort there (instead of panicing later when being unable to log in)
* Allow to export the stanza error info

Thanks @ge0rg for letting me test this.