### PR TITLE
client: use a try-able semaphore instead of a mutex for the session

### DIFF
--- a/cmd/xmpp_blackbox_exporter/xmpp_blackbox_exporter.go
+++ b/cmd/xmpp_blackbox_exporter/xmpp_blackbox_exporter.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
 	"net/http"
 	"os"
 	"os/signal"
@@ -11,8 +13,6 @@ import (
 	"sync"
 	"syscall"
 	"time"
-	"go.uber.org/zap"
-	"go.uber.org/zap/zapcore"
 
 	"mellium.im/xmpp/jid"
 

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/prometheus/common v0.20.0
 	github.com/stretchr/testify v1.7.0
 	go.uber.org/zap v1.13.0
+	golang.org/x/sync v0.0.0-20201207232520-09787c993a3a
 	gopkg.in/yaml.v2 v2.4.0
 	mellium.im/sasl v0.2.1
 	mellium.im/xmlstream v0.15.2

--- a/go.sum
+++ b/go.sum
@@ -339,6 +339,7 @@ golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20190227155943-e225da77a7e6/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20201207232520-09787c993a3a h1:DcqTD9SDLc+1P/r1EmRBwnVsrOwW+kk2vWf9n+1sGhs=
 golang.org/x/sync v0.0.0-20201207232520-09787c993a3a/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180823144017-11551d06cbcc/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=

--- a/internal/prober/c2s_tls.go
+++ b/internal/prober/c2s_tls.go
@@ -4,9 +4,9 @@ import (
 	"context"
 	"crypto/tls"
 	"errors"
+	"go.uber.org/zap"
 	"net"
 	"time"
-	"go.uber.org/zap"
 
 	"mellium.im/xmpp"
 	"mellium.im/xmpp/jid"

--- a/internal/prober/client.go
+++ b/internal/prober/client.go
@@ -5,10 +5,10 @@ import (
 	"crypto/tls"
 	"encoding/xml"
 	"errors"
+	"go.uber.org/zap"
 	"net"
 	"sync"
 	"time"
-	"go.uber.org/zap"
 
 	"mellium.im/sasl"
 	"mellium.im/xmlstream"

--- a/internal/prober/ibr.go
+++ b/internal/prober/ibr.go
@@ -4,9 +4,9 @@ import (
 	"context"
 	"crypto/tls"
 	"encoding/xml"
+	"go.uber.org/zap"
 	"net"
 	"time"
-	"go.uber.org/zap"
 
 	"github.com/prometheus/client_golang/prometheus"
 

--- a/internal/prober/ping.go
+++ b/internal/prober/ping.go
@@ -3,9 +3,9 @@ package prober
 import (
 	"context"
 	"encoding/xml"
+	"go.uber.org/zap"
 	"net"
 	"time"
-	"go.uber.org/zap"
 
 	"mellium.im/xmlstream"
 	"mellium.im/xmpp"

--- a/internal/prober/s2s_tls.go
+++ b/internal/prober/s2s_tls.go
@@ -4,9 +4,9 @@ import (
 	"context"
 	"crypto/tls"
 	"fmt"
+	"go.uber.org/zap"
 	"net"
 	"time"
-	"go.uber.org/zap"
 
 	"mellium.im/xmpp"
 	"mellium.im/xmpp/jid"


### PR DESCRIPTION
The key advantage is that if the session creation gets stuck for
any reason, the other probes which attempt to use the session will
still eventually cancel and return a result to the caller.

This is of importance as a matter of resilience; if other probes
get stuck on a shared session (because they wait for the lock
forever), we end up consuming more and more filedescriptors (and
also spawning more and more goroutines) until eventually
everything breaks.